### PR TITLE
Add multi-endpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides tools for querying SPARQL en
 
 ## Usage
 
-Example usage for querying the Wikidata SPARQL endpoint.
+Example usage for querying a single SPARQL endpoint or multiple endpoints defined in a configuration file.
 
 ### uvx
 
@@ -13,6 +13,17 @@ Example usage for querying the Wikidata SPARQL endpoint.
   "mcp-server-sparql": {
     "command": "uvx",
     "args": ["mcp-server-sparql", "--endpoint", "https://query.wikidata.org/sparql"],
+  }
+}
+```
+
+To load multiple endpoints from a configuration file:
+
+```json
+"mcpServers": {
+  "mcp-server-sparql": {
+    "command": "uvx",
+    "args": ["mcp-server-sparql", "--config", "config.json"],
   }
 }
 ```
@@ -28,3 +39,5 @@ Execute a SPARQL query against the configured endpoint.
 **Returns:**
 
 - The query results in JSON format
+
+For configuring multiple endpoints see [docs/config.md](docs/config.md).

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,38 @@
+# Configuring Multiple SPARQL Endpoints
+
+`mcp-server-sparql` can be configured to expose multiple SPARQL endpoints at once. Tools will be generated dynamically for each endpoint defined in a JSON configuration file.
+
+## Configuration File Structure
+
+Create a JSON file with the following structure:
+
+```json
+{
+  "endpoints": [
+    {
+      "name": "probe",
+      "url": "https://probe.stad.gent/sparql",
+      "instructions": "Use this endpoint for testing queries."
+    },
+    {
+      "name": "production",
+      "url": "https://stad.gent/sparql",
+      "instructions": "Production dataset. Do not run heavy experimental queries."
+    }
+  ]
+}
+```
+
+- `name` – unique identifier. The tool will be registered as `query_<name>`.
+- `url` – SPARQL endpoint URL.
+- `instructions` – text inserted in the tool description to guide the LLM about when to use this endpoint.
+
+## Running the Server
+
+Pass the configuration file path to the server:
+
+```bash
+uvx mcp-server-sparql --config config.json
+```
+
+Each endpoint will register a tool named `query_<name>` accepting a single `query_string` parameter.

--- a/docs/example_config.json
+++ b/docs/example_config.json
@@ -1,0 +1,14 @@
+{
+  "endpoints": [
+    {
+      "name": "probe",
+      "url": "https://probe.stad.gent/sparql",
+      "instructions": "Use this endpoint for testing queries."
+    },
+    {
+      "name": "production",
+      "url": "https://stad.gent/sparql",
+      "instructions": "Production dataset. Do not run heavy experimental queries."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add ability to load multiple endpoints from a JSON config
- document the configuration format and provide an example
- update README with usage of `--config`

## Testing
- `ruff check .`
- `pyright` *(fails: Import "SPARQLWrapper" could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_685459fef0ac832a942d0fd1bb82c8f4